### PR TITLE
Use createLogStream from mmm

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -61,15 +61,9 @@ function updateIndexes(entry, callback)
 	callback && callback();
 }
 
-// Large hack until multi-master-merge createValueStream is faster
-// TODO: now we have mmm .createLogStream, use that
-var protobuf = require("multi-master-merge/node_modules/protocol-buffers");
-var messages = protobuf(require("fs").readFileSync(__dirname+"/../node_modules/multi-master-merge/schema.proto"));
-db.log.createReadStream({ valueEncoding: "binary" }).on("data", function(entry) {
-	var en = messages.Entry.decode(entry.entry);
-	updateIndexes({ peer: entry.peer, seq: entry.seq, value: mmmEnc.decode(en.value) });
+db.createLogStream().on("data", function(entry) {
+	updateIndexes({ peer: entry.peer, seq: entry.seq, value: entry.value });
 }).on("end", function() { db.evs.emit("idxready") });
-
 
 /* Compact with old events API
  * this should maybe be obsoleted?

--- a/lib/retriever.js
+++ b/lib/retriever.js
@@ -5,7 +5,7 @@ var request = require("needle"),
     util = require("util"),
     cfg = require("./cfg"),
     torrentStream = require("torrent-stream"),
-    bencode = require("parse-torrent/node_modules/parse-torrent-file/node_modules/bencode"),
+    bencode = require("bencode"),
     parseTorrent = require("parse-torrent");
 
 var downloadSources = cfg.retrieverSources || [];


### PR DESCRIPTION
I've been trying to get `multipass-www` running and ran into problems with the `require()`s in this pull.

For the `createReadStream` I migrated things to the new API, since it's there: https://github.com/Ivshti/multi-master-merge/commit/4da9c16d2f50e6d4f232a3fa8f2b0de37bd6fd38

And I think the bencode require is fine.
